### PR TITLE
Fix key for StatusHead, allow null for previousVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
+- Fix changes to some model elements
+
+### 2.0.0
+
 - BREAKING--Convert datastar models to dynastar models
-  - Integration tests run against localstack instance 
+  - Integration tests run against localstack instance
 - [#4] Update documentation
   - Add badges
   - Add collected docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-- Fix changes to some model elements
+- Fix key for StatusHead, allow null for previousVersion
 
 ### 2.0.0
 

--- a/status-head.js
+++ b/status-head.js
@@ -12,7 +12,7 @@ const Joi = require('joi');
 module.exports = function statushead(dynamo) {
   const hashKey = 'key';
   const createKey = (data) => {
-    return `${data.pkg}!${data.env}!${data.version}`;
+    return `${data.pkg}!${data.env}`;
   };
   const model = dynamo.define('StatusHead', {
     hashKey,
@@ -23,7 +23,7 @@ module.exports = function statushead(dynamo) {
       pkg: Joi.string(),
       env: Joi.string(),
       version: Joi.string(),
-      previousVersion: Joi.string(),
+      previousVersion: Joi.string().allow(null),
       total: Joi.number()
     }
   });

--- a/status.js
+++ b/status.js
@@ -24,7 +24,7 @@ module.exports = function status(dynamo) {
       pkg: Joi.string(),
       env: Joi.string(),
       version: Joi.string(),
-      previousVersion: Joi.string(),
+      previousVersion: Joi.string().allow(null),
       total: Joi.number(),
       error: Joi.boolean(),
       complete: Joi.boolean()


### PR DESCRIPTION

## Summary

These changes are needed for https://github.com/godaddy/warehouse.ai-status-api/pull/20

## Changelog

Fix key for StatusHead, allow null for previousVersion

## Test Plan

These changes were tested concurrently with https://github.com/godaddy/warehouse.ai-status-api/pull/20
