### PR TITLE
Drop node@8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: required
 language: node_js
 node_js:
-  - "8"
   - "10"
   - "12"
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Remove Travis build for `node@8`, it was already unsupported due to requiring `stream.pipeline` and is well past LTS support.
+
 ### 2.0.3
 
 - Update dynastar to `^1.2.0`


### PR DESCRIPTION
This PR just drops the travis build for `node@8`. We already didn't support it any longer due to needing node's [`stream.pipeline`](https://nodejs.org/dist/latest-v12.x/docs/api/stream.html#stream_stream_pipeline_streams_callback) which was introduced in `node@10`

## Summary

This fixes the build failures.

## Changelog

Updated in the PR

## Test Plan

N/A this is dropping an existing build that was broken.
